### PR TITLE
[v-mr1] AndroidProducts: Set release configuration to trunk_staging

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -15,5 +15,5 @@
 PRODUCT_MAKEFILES := $(LOCAL_DIR)/aosp_xqbq52.mk
 
 COMMON_LUNCH_CHOICES += \
-    aosp_xqbq52-eng \
-    aosp_xqbq52-userdebug
+    aosp_xqbq52-trunk_staging-eng \
+    aosp_xqbq52-trunk_staging-userdebug


### PR DESCRIPTION
Starting with the latest revisions of Android 14 the string
representing the target has the following format:
product_name-release_config-build_variant.
trunk_staging is the development release configuration.